### PR TITLE
feat: replace MODULE* environment variables names by MFMODULE* (MODUL…

### DIFF
--- a/cookiecutter/_{{cookiecutter.repo}}/.metwork-framework/configure_a_metwork_package.md
+++ b/cookiecutter/_{{cookiecutter.repo}}/.metwork-framework/configure_a_metwork_package.md
@@ -20,9 +20,9 @@ Please read everything from the beginning to be sure to really understand the co
 
 #### Find the module configuration file `config.ini`
 
-You will find the module configuration file in `${MODULE_RUNTIME_HOME}/config/config.ini` path.
+You will find the module configuration file in `${MFMODULE_RUNTIME_HOME}/config/config.ini` path.
 
-If you are developing with a standard metwork installation using a standard metwork user like `mfserv`, `mfdata`..., `${MODULE_RUNTIME_HOME}`
+If you are developing with a standard metwork installation using a standard metwork user like `mfserv`, `mfdata`..., `${MFMODULE_RUNTIME_HOME}`
 is the home directory of the current user. So, if you are developing with `mfserv` user, you will find the module configuration file
 in `~/config/config.ini`.
 
@@ -44,14 +44,14 @@ The beginning of the file is something like that:
 [...]
 ```
 
-So this file overrides `${MODULE_HOME}/config/config.ini` (`${MODULE_HOME}` is in `/opt` in a standard metwork installation).
+So this file overrides `${MFMODULE_HOME}/config/config.ini` (`${MFMODULE_HOME}` is in `/opt` in a standard metwork installation).
 
-**never change anything in `${MODULE_HOME}/config/config.ini`**
+**never change anything in `${MFMODULE_HOME}/config/config.ini`**
 *(because this file is silently overriden after each metwork upgrade)*
 
-So, you have to do your modifications in `${MODULE_RUNTIME_HOME}/config/config.ini` file (probably hosted in `/home`).
+So, you have to do your modifications in `${MFMODULE_RUNTIME_HOME}/config/config.ini` file (probably hosted in `/home`).
 
-Note that, by default, all keys are commented. In that case, default values are read in `${MODULE_HOME}/config/config.ini`.
+Note that, by default, all keys are commented. In that case, default values are read in `${MFMODULE_HOME}/config/config.ini`.
 
 #### Override a key
 
@@ -59,7 +59,7 @@ To override a configuration option, select the corresponding key, uncomment it a
 
 For example, to override the listening port of nginx daemon for `mfserv` module:
 
-- edit `${MODULE_RUNTIME_HOME}/config/config.ini` as the user you use to run `mfserv` module
+- edit `${MFMODULE_RUNTIME_HOME}/config/config.ini` as the user you use to run `mfserv` module
 - find `[nginx]` section
 - uncomment `port=...` key below
 - change the value (for example `8080`)
@@ -73,7 +73,7 @@ Only this environment variable will be used by the rest of the module.
 To resume the previous example, the key `port` in `[nginx]` section of the `mfserv` configuration file is put into
 `MFSERV_NGINX_PORT` environment variable.
 
-In a more general way, every configuration option of module is stored in an environment variable: `{MODULE}_{SECTION}_{KEY}`.
+In a more general way, every configuration option of module is stored in an environment variable: `{MFMODULE}_{SECTION}_{KEY}`.
 
 And this environment variable is set **only during profile loading**.
 
@@ -88,32 +88,32 @@ newly restarted terminal or from a `root` user through `service metwork restart`
 To get current environment variables values for the current module, you can use for example:
 
 ```bash
-env |grep "^${MODULE}_"
+env |grep "^${MFMODULE}_"
 ```
 
 #### Understand what is overriden during module upgrades
 
 During a metwork module upgrade :
 
-- the default values file `${MODULE_HOME}/config/config.ini` (most of the time in `opt`) is silently overriden
-- the custom values file `${MODULE_RUNTIME_HOME}/config/config.ini` (most of the time in `home`) is overriden by a new default one **only if there is no change in it**
+- the default values file `${MFMODULE_HOME}/config/config.ini` (most of the time in `opt`) is silently overriden
+- the custom values file `${MFMODULE_RUNTIME_HOME}/config/config.ini` (most of the time in `home`) is overriden by a new default one **only if there is no change in it**
 
-So, if you changed some keys in `${MODULE_RUNTIME_HOME}/config/config.ini`, your change will never be overriden by a metwork upgrade.
+So, if you changed some keys in `${MFMODULE_RUNTIME_HOME}/config/config.ini`, your change will never be overriden by a metwork upgrade.
 
-But the upgrade add a new configuration option, the new configuration option will be (of course) visible in `${MODULE_HOME}/config/config.ini` but not in your `${MODULE_RUNTIME_HOME}/config/config.ini` (because we prefer to keep your changes). It's not a problem in itself but you can miss some configuration options.
+But the upgrade add a new configuration option, the new configuration option will be (of course) visible in `${MFMODULE_HOME}/config/config.ini` but not in your `${MFMODULE_RUNTIME_HOME}/config/config.ini` (because we prefer to keep your changes). It's not a problem in itself but you can miss some configuration options.
 
-So, when you do some metwork ugprades on a customized system, you should sometimes do a kind of diff/merge between `${MODULE_RUNTIME_HOME}/config/config.ini` and `${MODULE_HOME}/config/config.ini`.
+So, when you do some metwork ugprades on a customized system, you should sometimes do a kind of diff/merge between `${MFMODULE_RUNTIME_HOME}/config/config.ini` and `${MFMODULE_HOME}/config/config.ini`.
 
 But again: if you don't do this, it won't break anything. But you can just miss some new configuration features.
 
 ### How to configure plugins during development process ?
 
 If you are working on a plugin named `foo` which need extra configuration variables, add a section to
-`${MODULE_RUNTIME_HOME}/config/config.ini` named `[plugin_foo]`. For example, for a `mfserv` plugin:
+`${MFMODULE_RUNTIME_HOME}/config/config.ini` named `[plugin_foo]`. For example, for a `mfserv` plugin:
 
 ```cfg
 # [...]
-# At the end of ${MODULE_RUNTIME_HOME}/config/config.ini
+# At the end of ${MFMODULE_RUNTIME_HOME}/config/config.ini
 
 [plugin_foo]
 key1=value1
@@ -176,7 +176,7 @@ port=8080
 
 The file must be readable by metwork users.
 
-When this file is created and when you (re)load the `mfserv` profile, the file `${MODULE_RUNTIME_HOME}/config/config.ini` is silently replaced by a symbolic link: `${MODULE_RUNTIME_HOME}/config/config.ini -> /etc/metwork.config.d/mfserv/config.ini`.
+When this file is created and when you (re)load the `mfserv` profile, the file `${MFMODULE_RUNTIME_HOME}/config/config.ini` is silently replaced by a symbolic link: `${MFMODULE_RUNTIME_HOME}/config/config.ini -> /etc/metwork.config.d/mfserv/config.ini`.
 
 After that, you have to configure your module through this `/etc` file.
 

--- a/cookiecutter/_{{cookiecutter.repo}}/.metwork-framework/plugins_guide.md
+++ b/cookiecutter/_{{cookiecutter.repo}}/.metwork-framework/plugins_guide.md
@@ -13,17 +13,17 @@ Every time you change the configuration file, you have to stop and start the Met
 
 - either
 ```bash
-{MODULE_RUNTIME_HOME}.stop
-{MODULE_RUNTIME_HOME}.start
+{MFMODULE_RUNTIME_HOME}.stop
+{MFMODULE_RUNTIME_HOME}.start
 ```
 - or (as root user)
 ```bash
-service metwork restart {MODULE_RUNTIME_HOME}
+service metwork restart {MFMODULE_RUNTIME_HOME}
 ```
 
-with {MODULE_RUNTIME_HOME} the Metwork module you are working with, e.g. mfdata.
+with {MFMODULE_RUNTIME_HOME} the Metwork module you are working with, e.g. mfdata.
 
-The configuration parameters are described and explained in the `${MODULE_RUNTIME_HOME}/config/config.ini` file.
+The configuration parameters are described and explained in the `${MFMODULE_RUNTIME_HOME}/config/config.ini` file.
 
 ## Plugins Commands
 
@@ -73,7 +73,7 @@ If you have a "normal" installed plugin, you can use `plugin_env {PLUGIN_NAME}`.
 
 When you are inside a plugin environment, you will find some extra environment variables:
 ```bash
-env | grep "^${MODULE}_" | grep CURRENT
+env | grep "^${MFMODULE}_" | grep CURRENT
 ```
 
 ```

--- a/cookiecutter/_{{cookiecutter.repo}}/doc/conf.py
+++ b/cookiecutter/_{{cookiecutter.repo}}/doc/conf.py
@@ -9,7 +9,7 @@ def get_version():
     """
     :return: # The short X.Y version.
     """
-    return ".".join(os.environ.get('MODULE_VERSION',
+    return ".".join(os.environ.get('MFMODULE_VERSION',
                                    'unknown.unknown').split('.')[0:-1])
 
 
@@ -17,7 +17,7 @@ def get_release():
     """
     :return: the full version, including alpha/beta/rc tags
     """
-    return os.environ.get('MODULE_VERSION', 'unknown')
+    return os.environ.get('MFMODULE_VERSION', 'unknown')
 
 
 

--- a/cookiecutter/_{{cookiecutter.repo}}/integration_tests/0095_suspicious_dependencies/test.sh
+++ b/cookiecutter/_{{cookiecutter.repo}}/integration_tests/0095_suspicious_dependencies/test.sh
@@ -6,7 +6,7 @@ export PATH=${PATH}:${PWD}/..
 RET=0
 FIC_DEPS=`pwd`/deps
 {% if "mfext-addon" not in "REPO_TOPICS"|getenv|from_json %}
-cd "${MODULE_HOME}" || exit 1
+cd "${MFMODULE_HOME}" || exit 1
 external_dependencies.sh >${FIC_DEPS}
 for F in $(cat ${FIC_DEPS}); do
     N=$(ldd "${F}" 2>/dev/null |grep -c metwork)

--- a/cookiecutter/_{{cookiecutter.repo}}/integration_tests/0096_system_extra_dependencies/test.sh
+++ b/cookiecutter/_{{cookiecutter.repo}}/integration_tests/0096_system_extra_dependencies/test.sh
@@ -13,7 +13,7 @@ export PATH=${PATH}:${PWD}/..
 RET=0
 
 {% if "mfext-addon" not in "REPO_TOPICS"|getenv|from_json %}
-cd "${MODULE_HOME}" || exit 1
+cd "${MFMODULE_HOME}" || exit 1
 DEPS1=$(external_dependencies.sh |awk -F '/' '{print $NF}' |xargs)
 DEPS2=$(external_dependencies_not_found.sh |xargs)
 DEPS=$(echo $DEPS1 $DEPS2)

--- a/cookiecutter/_{{cookiecutter.repo}}/integration_tests/mfxxx_run_integration_tests.sh
+++ b/cookiecutter/_{{cookiecutter.repo}}/integration_tests/mfxxx_run_integration_tests.sh
@@ -18,7 +18,7 @@ for rep in $list_rep; do
         fi
         for test in test*; do
             echo "Test" $test "in" $rep
-            for F in $(ls ${MODULE_RUNTIME_HOME}/log/*.log ${MODULE_RUNTIME_HOME}/log/*.stdout ${MODULE_RUNTIME_HOME}/log/*.stderr 2>/dev/null); do
+            for F in $(ls ${MFMODULE_RUNTIME_HOME}/log/*.log ${MFMODULE_RUNTIME_HOME}/log/*.stdout ${MFMODULE_RUNTIME_HOME}/log/*.stderr 2>/dev/null); do
                 truncate -s 0 "${F}"
             done
             if test $WRAPPER -eq 0; then
@@ -29,7 +29,7 @@ for rep in $list_rep; do
             if test $? == 0; then
                 echo "Test $test ($rep) OK"
             else
-                for F in $(ls ${MODULE_RUNTIME_HOME}/log/*.log ${MODULE_RUNTIME_HOME}/log/*.stdout ${MODULE_RUNTIME_HOME}/log/*.stderr 2>/dev/null); do
+                for F in $(ls ${MFMODULE_RUNTIME_HOME}/log/*.log ${MFMODULE_RUNTIME_HOME}/log/*.stdout ${MFMODULE_RUNTIME_HOME}/log/*.stderr 2>/dev/null); do
                     if test -s "${F}"; then
                         echo "===== 40 last lines of ${F} to debug ====="
                         tail -40 "${F}"
@@ -37,7 +37,7 @@ for rep in $list_rep; do
                         echo ""
                     fi
                 done
-                for F in ${MODULE_RUNTIME_HOME}/tmp/config_auto/nginx.conf ${MODULE_RUNTIME_HOME}/tmp/config_auto/circus.ini; do
+                for F in ${MFMODULE_RUNTIME_HOME}/tmp/config_auto/nginx.conf ${MFMODULE_RUNTIME_HOME}/tmp/config_auto/circus.ini; do
                     if test -f "${F}"; then
                         echo "===== ${F} content to debug ====="
                         cat "${F}"

--- a/cookiecutter/_{{cookiecutter.repo}}/mfextaddon_bootstrap.sh
+++ b/cookiecutter/_{{cookiecutter.repo}}/mfextaddon_bootstrap.sh
@@ -29,12 +29,12 @@ MFEXT_HOME=$(get_abs_filename "$1")
 export MFEXT_HOME
 MFEXT_VERSION=$(cat "${MFEXT_HOME}/config/version")
 export MFEXT_VERSION
-MODULE_VERSION=$("${MFEXT_HOME}/bin/guess_version.sh")
-export MODULE_VERSION
-export MODULE_HOME=${MFEXT_HOME}
+MFMODULE_VERSION=$("${MFEXT_HOME}/bin/guess_version.sh")
+export MFMODULE_VERSION
+export MFMODULE_HOME=${MFEXT_HOME}
 
-export MODULE=MFEXT
-export MODULE_LOWERCASE=mfext
+export MFMODULE=MFEXT
+export MFMODULE_LOWERCASE=mfext
 export MFEXTADDON=1
 SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export SRC_DIR
@@ -50,15 +50,15 @@ rm -f adm/root.mk adm/envtpl
 touch adm/root.mk
 ln -s "${MFEXT_HOME}/bin/envtpl" adm/envtpl
 
-echo "export MODULE := ${MODULE}" >>adm/root.mk
-echo "export MODULE_LOWERCASE := $(echo ${MODULE} | tr '[:upper:]' '[:lower:]')" >>adm/root.mk
+echo "export MFMODULE := ${MFMODULE}" >>adm/root.mk
+echo "export MFMODULE_LOWERCASE := $(echo ${MFMODULE} | tr '[:upper:]' '[:lower:]')" >>adm/root.mk
 echo "export LAYERAPI2_LAYERS_PATH := ${MFEXT_HOME}/opt:${MFEXT_HOME}" >>adm/root.mk
 echo "export MFEXT_HOME := ${MFEXT_HOME}" >>adm/root.mk
 echo "export MFEXT_ADDON := 1" >>adm/root.mk
 echo "export MFEXT_ADDON_NAME := {{MFEXT_ADDON_NAME}}" >>adm/root.mk
 echo "export MFEXT_VERSION := ${MFEXT_VERSION}" >>adm/root.mk
-echo "export MODULE_HOME := ${MODULE_HOME}" >>adm/root.mk
-echo "export MODULE_VERSION := ${MFEXT_VERSION}" >>adm/root.mk
+echo "export MFMODULE_HOME := ${MFMODULE_HOME}" >>adm/root.mk
+echo "export MFMODULE_VERSION := ${MFEXT_VERSION}" >>adm/root.mk
 echo "export SRC_DIR := ${SRC_DIR}" >>adm/root.mk
 echo "ifeq (\$(FORCED_PATHS),)" >>adm/root.mk
 echo "  export PATH := ${ROOT_PATH}" >>adm/root.mk

--- a/cookiecutter/_{{cookiecutter.repo}}/mfxxx_bootstrap.sh
+++ b/cookiecutter/_{{cookiecutter.repo}}/mfxxx_bootstrap.sh
@@ -45,14 +45,14 @@ MFCOM_VERSION=$(cat "${MFCOM_HOME}/config/version")
 export MFCOM_VERSION
 {{MODULE}}_VERSION=$("${MFEXT_HOME}/bin/guess_version.sh")
 export {{MODULE}}_VERSION
-MODULE_VERSION=$("${MFEXT_HOME}/bin/guess_version.sh")
-export MODULE_VERSION
+MFMODULE_VERSION=$("${MFEXT_HOME}/bin/guess_version.sh")
+export MFMODULE_VERSION
 
-MODULE_HOME=$(get_abs_filename "$1")
-export MODULE_HOME
-if ! test -d "${MODULE_HOME}"; then
+MFMODULE_HOME=$(get_abs_filename "$1")
+export MFMODULE_HOME
+if ! test -d "${MFMODULE_HOME}"; then
     usage
-    echo "ERROR: ${MODULE_HOME} is not a directory"
+    echo "ERROR: ${MFMODULE_HOME} is not a directory"
     exit 1
 fi
 
@@ -65,8 +65,8 @@ if ! test -f "${MFCOM_HOME}/bin/mfcom_wrapper"; then
     exit 1
 fi
 
-export MODULE={{MODULE}}
-export MODULE_LOWERCASE={{cookiecutter.repo}}
+export MFMODULE={{MODULE}}
+export MFMODULE_LOWERCASE={{cookiecutter.repo}}
 SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export SRC_DIR
 
@@ -78,23 +78,23 @@ touch adm/root.mk
 ROOT_PATH=${MFCOM_HOME}/bin:${MFEXT_HOME}/bin:${MFEXT_HOME}/opt/core/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ROOT_LD_LIBRARY_PATH=""
 ROOT_PKG_CONFIG_PATH=""
-ROOT_LAYERAPI2_LAYERS_PATH=${MODULE_HOME}/opt:${MODULE_HOME}:${MFCOM_HOME}/opt:${MFCOM_HOME}:${MFEXT_HOME}/opt:${MFEXT_HOME}
+ROOT_LAYERAPI2_LAYERS_PATH=${MFMODULE_HOME}/opt:${MFMODULE_HOME}:${MFCOM_HOME}/opt:${MFCOM_HOME}:${MFEXT_HOME}/opt:${MFEXT_HOME}
 
 echo "Making adm/root.mk..."
 rm -f adm/root.mk
 touch adm/root.mk
 
-echo "unexport MODULE_RUNTIME_HOME" >>adm/root.mk
-echo "unexport MODULE_RUNTIME_SUFFIX" >>adm/root.mk
-echo "unexport MODULE_RUNTIME_USER" >>adm/root.mk
+echo "unexport MFMODULE_RUNTIME_HOME" >>adm/root.mk
+echo "unexport MFMODULE_RUNTIME_SUFFIX" >>adm/root.mk
+echo "unexport MFMODULE_RUNTIME_USER" >>adm/root.mk
 
-echo "export MODULE := ${MODULE}" >>adm/root.mk
-echo "export MODULE_LOWERCASE := $(echo ${MODULE} | tr '[:upper:]' '[:lower:]')" >>adm/root.mk
+echo "export MFMODULE := ${MFMODULE}" >>adm/root.mk
+echo "export MFMODULE_LOWERCASE := $(echo ${MFMODULE} | tr '[:upper:]' '[:lower:]')" >>adm/root.mk
 echo "export LAYERAPI2_LAYERS_PATH := ${ROOT_LAYERAPI2_LAYERS_PATH}" >>adm/root.mk
 echo "export MFEXT_HOME := ${MFEXT_HOME}" >>adm/root.mk
 echo "export MFEXT_VERSION := ${MFEXT_VERSION}" >>adm/root.mk
-echo "export MODULE_HOME := ${MODULE_HOME}" >>adm/root.mk
-echo "export MODULE_VERSION := {% raw %}${{% endraw %}{{MODULE}}_VERSION}" >>adm/root.mk
+echo "export MFMODULE_HOME := ${MFMODULE_HOME}" >>adm/root.mk
+echo "export MFMODULE_VERSION := {% raw %}${{% endraw %}{{MODULE}}_VERSION}" >>adm/root.mk
 echo "export SRC_DIR := ${SRC_DIR}" >>adm/root.mk
 echo "ifeq (\$(FORCED_PATHS),)" >>adm/root.mk
 echo "  export PATH := ${ROOT_PATH}" >>adm/root.mk
@@ -105,8 +105,8 @@ echo "  \$(foreach LAYER_ENV, \$(LAYER_ENVS), \$(eval unexport \$(LAYER_ENV)))" 
 echo "endif" >>adm/root.mk
 echo "export MFCOM_HOME := ${MFCOM_HOME}" >>adm/root.mk
 echo "export MFCOM_VERSION := ${MFCOM_VERSION}" >>adm/root.mk
-echo "export ${MODULE}_HOME := ${MODULE_HOME}" >>adm/root.mk
-echo "export ${MODULE}_VERSION := {% raw %}${{% endraw %}{{MODULE}}_VERSION}" >>adm/root.mk
+echo "export ${MFMODULE}_HOME := ${MFMODULE_HOME}" >>adm/root.mk
+echo "export ${MFMODULE}_VERSION := {% raw %}${{% endraw %}{{MODULE}}_VERSION}" >>adm/root.mk
 if test "${MODULE_HAS_HOME_DIR:-}" = "1"; then
     echo "export MODULE_HAS_HOME_DIR := 1" >>adm/root.mk
 fi


### PR DESCRIPTION
…E_HOME becomes MFMODULE_HOME and so on)

BREAKING CHANGE: old variables names are no longer defined, they should not be used anymore (be careful with existing plugins)